### PR TITLE
Fix the bug with requiring names to be lowercaselkgsdfkl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v3.0.1
+Fixed the bug that disallowed capital letters in `dex:*` commands
+
 ## v3.0.0
  - Switched to commando
  - Removed mod commands for security reasons

--- a/util/parsearg.js
+++ b/util/parsearg.js
@@ -42,7 +42,7 @@ module.exports = function parseArg (value, aliases) {
       currentOne = spliceSlice(currentOne, stuffToRemove[i] - numChanged, 1)
       numChanged++
     }
-    modifiedValue = currentOne.toLowerCase()
+    modifiedValue = currentOne
   }
-  return modifiedValue
+  return modifiedValue.toLowerCase()
 }


### PR DESCRIPTION
<!--
  Hey! Thanks for contributing!
  Please fill out the template below to fill us in on what you are contributing to the project
-->
Features Introduced
-------------------
Fixes the fact that things like `%md Geomancy` won't work due to capital letters (especially a problem since `%randmon` provides capitalized mons)

Elements Affected
-----------------
Any `dex:*` commands